### PR TITLE
$destroy event should be bounded to $scope

### DIFF
--- a/src/gridstackitem.directive.js
+++ b/src/gridstackitem.directive.js
@@ -49,7 +49,7 @@
           scope.gsItemHeight = val;
         });
 
-        element.bind('$destroy', function() {
+        scope.$on('$destroy', function() {
           var item = element.data('_gridstack_node');
           scope.onItemRemoved({item: item});
           controller.removeItem(element);


### PR DESCRIPTION
Rather than binding $destroy it to element, it should be bounded to $scope, so when $destroy event broadcasted while destroy, it will fire up remove gridStackItem DOM to avoid memory leaking