### PR TITLE
Expose gridstack object to Directive

### DIFF
--- a/src/gridstack.directive.js
+++ b/src/gridstack.directive.js
@@ -15,12 +15,14 @@
         onDragStop: '&',
         onResizeStart: '&',
         onResizeStop: '&',
+        gridstackHandler: '=',
         options: '='
       },
       link: function (scope, element, attrs, controller, ngModel) {
 
-        controller.init(element, scope.options);
-
+        var gridstack = controller.init(element, scope.options);
+        scope.gridstackHandler = gridstack;
+        
         element.on('change', function (e, items) {
           $timeout(function() {
             scope.$apply();


### PR DESCRIPTION
In order to access gridstack's API within AngularJS application. We need to expose `gridstack` object which was created in `GridstackController`.

**Usage:**

When init the HTML template for gridstack:

```html
<div gridstack gridstack-handler="gridstacker" options="options">
   ...
</div>
```

In your AngularJS application:

```js
$scope.gridstacker = null;
```

Don't forget to check for `gridstacker` availability before using:

```js
if ($scope.gridstacker) {
    $scope.gridstacker.removeAll(); // example: call removeAll() API
}
```