### PR TITLE
Exposes the id of the widget

### DIFF
--- a/src/gridstackitem.directive.js
+++ b/src/gridstackitem.directive.js
@@ -35,7 +35,7 @@
         });
 
         scope.$watch(function () { return $(element).attr('data-gs-id'); }, function (val) {
-            scope.gsId = val;
+            scope.gsItemId = val;
         });
         scope.$watch(function(){ return $(element).attr('data-gs-x'); }, function(val) {
           scope.gsItemX = val;

--- a/src/gridstackitem.directive.js
+++ b/src/gridstackitem.directive.js
@@ -14,6 +14,7 @@
         gridstackItem: '=',
         onItemAdded: '&',
         onItemRemoved: '&',
+        gsItemId: '=',
         gsItemX: '=',
         gsItemY: '=',
         gsItemWidth: '=',
@@ -21,7 +22,7 @@
         gsItemAutopos: '='
       },
       link: function (scope, element, attrs, controller) {
-
+        $(element).attr('data-gs-id', scope.gsItemId);
         $(element).attr('data-gs-x', scope.gsItemX);
         $(element).attr('data-gs-y', scope.gsItemY);
         $(element).attr('data-gs-width', scope.gsItemWidth);
@@ -33,6 +34,9 @@
           scope.onItemAdded({item: item});
         });
 
+        scope.$watch(function () { return $(element).attr('data-gs-id'); }, function (val) {
+            scope.gsId = val;
+        });
         scope.$watch(function(){ return $(element).attr('data-gs-x'); }, function(val) {
           scope.gsItemX = val;
         });


### PR DESCRIPTION
This is important when you are resizing the widgets. Depending on the widget name is the template that you would like to invoke. If you do not know the widget that is being resized then how will you know the inner html resizing algorithm that you need to use. Either way, this is an attribute gridstack already exposes.